### PR TITLE
Add MacPorts installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,17 @@ development by reporting bugs, you can install the prerelease version:
 $ brew install --devel hub
 ```
 
+#### MacPorts
+
+`hub` can be installed through MacPorts:
+
+``` sh
+$ sudo port install hub
+$ hub version
+git version 2.14.2
+hub version 2.2.9
+```
+
 #### Chocolatey
 
 `hub` can be installed through [Chocolatey](https://chocolatey.org/) on Windows.


### PR DESCRIPTION
NOTE: There doesn't appear that `hub` provides any variants (e.g. pre-releases).